### PR TITLE
Bump wagon to v0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 env: GO111MODULE=on
 
 go:
+  - 1.13.x
   - 1.12.x
   - 1.11.x
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/vertexdlt/vertexvm
 
 go 1.12
 
-require github.com/go-interpreter/wagon v0.5.0
+require github.com/go-interpreter/wagon v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/go-interpreter/wagon v0.5.0 h1:R3tt1YGrLoqRz5opwtWDVM+RMWZKjWFolsuhP+JM8+g=
-github.com/go-interpreter/wagon v0.5.0/go.mod h1:GE71kESYU2aIZfRHqqwiht+20EeJsFPQUPHO3tBvpCo=
-github.com/twitchyliquid64/golang-asm v0.0.0-20190315094337-365674df15fc h1:1e9rlv2uVxoE3VQQd/I0TvafsdYAvDplfOdypCiiV9I=
-github.com/twitchyliquid64/golang-asm v0.0.0-20190315094337-365674df15fc/go.mod h1:NoCfSFWosfqMqmmD7hApkirIK9ozpHjxRnRxs1l413A=
+github.com/go-interpreter/wagon v0.6.0 h1:BBxDxjiJiHgw9EdkYXAWs8NHhwnazZ5P2EWBW5hFNWw=
+github.com/go-interpreter/wagon v0.6.0/go.mod h1:5+b/MBYkclRZngKF5s6qrgWxSLgE9F5dFdO1hAueZLc=
+github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc h1:RTUQlKzoZZVG3umWNzOYeFecQLIh+dbxXvJp1zPQJTI=
+github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc/go.mod h1:NoCfSFWosfqMqmmD7hApkirIK9ozpHjxRnRxs1l413A=
 golang.org/x/sys v0.0.0-20190306220234-b354f8bf4d9e h1:UndnRDGP/JcdZX1LBubo1fJ3Jt6GnKREteLJvysiiPE=
 golang.org/x/sys v0.0.0-20190306220234-b354f8bf4d9e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
The current version, somehow causes bug while running `go mod tidy`

```
go: github.com/go-interpreter/wagon@v0.5.0 requires
        github.com/twitchyliquid64/golang-asm@v0.0.0-20190315094337-365674df15fc: invalid pseudo-version: does not match version-control timestamp (2019-01-26T20:37:39Z)
```